### PR TITLE
Improve highlight CSS for dark mode

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -36,11 +36,12 @@ async function main() {
     line-height: 1em;
     font-family: tabler-icons;
   }
-
-    span.${highlightClass} {
-      background-color: yellow;
-    }
-
+  span.${highlightClass} {
+    background-color: yellow;
+  }
+  .dark span.${highlightClass} {
+    background-color: #ffff0030;
+  }
   `)
 
   let unlinkObserver, unlinkedRefsContainer;


### PR DESCRIPTION
This improves the appearance of highlights in dark modes.

Before:
<img width="199" alt="Screen Shot 2022-11-08 at 22 44 41" src="https://user-images.githubusercontent.com/491376/200733253-b688dae0-0711-41b6-a3dd-b9df86317d22.png">
<img width="210" alt="Screen Shot 2022-11-08 at 22 45 50" src="https://user-images.githubusercontent.com/491376/200733582-ddf327bb-0a49-44bb-9714-31c3cb6e49b1.png">

After:
<img width="197" alt="Screen Shot 2022-11-08 at 22 44 17" src="https://user-images.githubusercontent.com/491376/200733257-877a0feb-62e3-44c4-8694-15b8d611b45d.png">
<img width="214" alt="Screen Shot 2022-11-08 at 22 46 09" src="https://user-images.githubusercontent.com/491376/200733593-c82edd3b-1e23-4c93-9650-e50e5e8aa0b2.png">
